### PR TITLE
Fix Piko upgrade issue for Deno version 2

### DIFF
--- a/upgrade.js
+++ b/upgrade.js
@@ -96,6 +96,7 @@ async function upgradePikoTo(version) {
             args: [
                 "install",
                 "-f",
+                "-g",
                 "-A",
                 "--location",
                 STORAGE_ORIGIN,


### PR DESCRIPTION
The global argument is specified in the installation instructions in the README file but is not provided when upgrading Piko.

Upgrading without the argument "-g" works in Deno version 1 but not in version 2.



